### PR TITLE
Adição das novas funcionalidades Clone e Copy

### DIFF
--- a/Pandemonium.Test/Extensions/IEnumerable/CopyTests.cs
+++ b/Pandemonium.Test/Extensions/IEnumerable/CopyTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace Pandemonium.Test.Extensions.IEnumerable
+{
+    public class CopyTests
+    {
+        [Fact]
+        public void Should_Clone_IEnumerable_Values_To_New_Reference()
+        {
+            IEnumerable<Sample> value = new List<Sample> { new Sample { Anything = "anything" } };
+
+            IEnumerable<Sample> copy = value.Copy();
+
+            Assert.False(value.Equals(copy));
+            Assert.Equal(value.First().Anything, copy.First().Anything);
+
+            value.First().Anything = "another";
+
+            Assert.NotEqual(value.First().Anything, copy.First().Anything);
+        }
+
+        [Fact]
+        public void Should_Clone_Array_Values_To_New_Reference()
+        {
+            int[] value = { 1, 2, 3 };
+
+            int[] copy = (int[])value.Copy();
+
+            Assert.False(value.Equals(copy));
+            Assert.Equal(value.First(), copy.First());
+        }
+
+        [Fact]
+        public void Should_Throw_SerializationException_Try_Serialize_Non_Serializeble_IEnumerable_Class()
+        {
+            IEnumerable<object> value = new List<object> { new { Anything = "anything" } };
+            Assert.Throws<SerializationException>(() => value.Copy());
+        }
+
+        [Serializable]
+        internal class Sample
+        {
+            public string Anything { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (!ReferenceEquals(this, obj))
+                {
+                    return false;
+                }
+
+                return base.Equals(obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode();
+            }
+        }
+    }
+}

--- a/Pandemonium.Test/Extensions/Object/CloneTests.cs
+++ b/Pandemonium.Test/Extensions/Object/CloneTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace Pandemonium.Test.Extensions.Object
+{
+    public class CloneTests
+    {
+        [Fact]
+        public void Should_Clone_Object_Values_To_New_Reference()
+        {
+            Sample value = new Sample { Anything = "anything" };
+
+            Sample newObject = value.Clone();
+
+            Assert.False(value.Equals(newObject));
+            Assert.Equal(value.Anything, newObject.Anything);
+
+            value.Anything = "another";
+
+            Assert.NotEqual(value.Anything, newObject.Anything);
+        }
+
+        [Fact]
+        public void Should_Throw_SerializationException_Try_Serialize_Non_Serializeble_Class()
+        {
+            object value = new { Anything = "anything" };
+            Assert.Throws<SerializationException>(() => value.Clone());
+        }
+    }
+
+    [Serializable]
+    internal class Sample
+    {
+        public string Anything { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (!ReferenceEquals(this, obj))
+            {
+                return false;
+            }
+
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/Pandemonium/Extensions/IEnumerable/IEnumerable.Copy.cs
+++ b/Pandemonium/Extensions/IEnumerable/IEnumerable.Copy.cs
@@ -5,7 +5,7 @@ namespace Pandemonium
     public static partial class Methods
     {
         /// <summary>
-        /// Return a non memory reference copy of enumeration. <b>The class of enumeration needs be Serializable</b>; 
+        /// Return a non memory reference copy of enumeration. <b>The type must be serializables</b>.
         /// </summary>
         public static IEnumerable<T> Copy<T>(this IEnumerable<T> @this)
             => @this.Clone();

--- a/Pandemonium/Extensions/IEnumerable/IEnumerable.Copy.cs
+++ b/Pandemonium/Extensions/IEnumerable/IEnumerable.Copy.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace Pandemonium
+{
+    public static partial class Methods
+    {
+        /// <summary>
+        /// Return a non memory reference copy of enumeration. <b>The class of enumeration needs be Serializable</b>; 
+        /// </summary>
+        public static IEnumerable<T> Copy<T>(this IEnumerable<T> @this)
+            => @this.Clone();
+    }
+}

--- a/Pandemonium/Extensions/Object/Object.Clone.cs
+++ b/Pandemonium/Extensions/Object/Object.Clone.cs
@@ -1,0 +1,22 @@
+﻿using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace Pandemonium
+{
+    public static partial class Methods
+    {
+        /// <summary>
+        /// Returns a clone of the object, with a new memory reference. <b>The class needs be Serializable</b>.
+        /// </summary>
+        public static T Clone<T>(this T @this)
+        {
+            MemoryStream stream = new MemoryStream();
+            IFormatter formatter = new BinaryFormatter();
+            formatter.Serialize(stream, @this);
+            stream.Seek(0, SeekOrigin.Begin);
+            object newObject = formatter.Deserialize(stream);
+            return (T)newObject;
+        }
+    }
+}

--- a/Pandemonium/Extensions/Object/Object.Clone.cs
+++ b/Pandemonium/Extensions/Object/Object.Clone.cs
@@ -7,16 +7,18 @@ namespace Pandemonium
     public static partial class Methods
     {
         /// <summary>
-        /// Returns a clone of the object, with a new memory reference. <b>The class needs be Serializable</b>.
+        /// Returns a clone of the object, with a new memory reference. <b>The type must be serializable</b>.
         /// </summary>
         public static T Clone<T>(this T @this)
         {
-            MemoryStream stream = new MemoryStream();
-            IFormatter formatter = new BinaryFormatter();
-            formatter.Serialize(stream, @this);
-            stream.Seek(0, SeekOrigin.Begin);
-            object newObject = formatter.Deserialize(stream);
-            return (T)newObject;
+            using (var stream = new MemoryStream())
+            {
+                IFormatter formatter = new BinaryFormatter();
+                formatter.Serialize(stream, @this);
+                stream.Seek(0, SeekOrigin.Begin);
+                object newObject = formatter.Deserialize(stream);
+                return (T)newObject;
+            }
         }
     }
 }

--- a/Pandemonium/Pandemonium.csproj
+++ b/Pandemonium/Pandemonium.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\Resources\logo_package.png" Pack="true" PackagePath=""/>
+    <None Include="..\Resources\logo_package.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adição das novas funcionalidades Clone e Copy

Object.Clone(): Usa a estratégia de serialização em memória para criar uma cópia dos dados e gerar uma nova referência totalmente independente do objeto original. O objeto que usar este método obrigatoriamente precisa ser uma instância de uma classe que possui o atributo "Serializable".

IEnumerable.Copy(): Seguindo a mesma ideia do Clone, mas voltado para classes que implementam a interface genérica IEnumerable<>, este método usa internamente o Object.Clone() para gerar uma nova referência de memória totalmente independente da anterior. A coleção genérica do tipo "T" obrigatoriamente precisa ser uma instância de uma classe que possui o atributo "Serializable".